### PR TITLE
Stop overwriting local_addrs and mx_check

### DIFF
--- a/install/assets/functions/10-rspamd
+++ b/install/assets/functions/10-rspamd
@@ -627,7 +627,7 @@ EOF
 configure_rspamd_options() {
 	if [ "$SETUP_TYPE" = "AUTO" ]; then
 	    print_notice "Configuring RSpamD Options"
-		cat <<EOF > /etc/rspamd/local.d/mx_check.conf
+		cat <<EOF > /etc/rspamd/local.d/rspamd_options.conf
 ## Custom Generated URL Tags Configuration! Do not edit, instead set ENV Vars
 ## If you want to use your own configuration files set SETUP_TYPE=MANUAL when starting container
 ## Last Generated on $(TZ=${TIMEZONE} date +'%Y-%m-%d %H:%M:%S %Z')
@@ -1253,7 +1253,7 @@ EOF
 configure_url_tags() {
 	if [ "$SETUP_TYPE" = "AUTO" ]; then
 	    print_notice "Configuring URL Tags Checking"
-		cat <<EOF > /etc/rspamd/local.d/mx_check.conf
+		cat <<EOF > /etc/rspamd/local.d/url_tags.conf
 ## Custom Generated URL Tags Configuration! Do not edit, instead set ENV Vars
 ## If you want to use your own configuration files set SETUP_TYPE=MANUAL when starting container
 ## Last Generated on $(TZ=${TIMEZONE} date +'%Y-%m-%d %H:%M:%S %Z')


### PR DESCRIPTION
The functions configure_mx_check(), configure_url_tags() and
configure_rspamd_options() have written the same file
(/etc/rspamd/local.d/mx_check.conf) multiple times. In the end only
the result of configure_url_tags() still exists.

This fix introduce separate files for url_tags and rspamd_options.
- /etc/rspamd/local.d/rspamd_options.conf
- /etc/rspamd/local.d/url_tags.conf